### PR TITLE
qastle version to support subscripts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         'flask',
         'Flask-WTF',
         'flask-restful',
-        'func-adl-xAOD.backend==1.0.0a19'
+        'func-adl-xAOD.backend==1.0.0a20'
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
The reason Marc's 8 column query wasn't working was missing support for subscripts in the `qastle` language. This update pulls the proper version of `func_adl.xAOD.backend` that uses that version of the library.

For the text of the query once this merge is done see https://github.com/iris-hep/func_adl.xAOD/issues/23